### PR TITLE
fix: close Keras backend session properly

### DIFF
--- a/cnn_keras.py
+++ b/cnn_keras.py
@@ -66,3 +66,4 @@ def train():
 	#model.save('cnn_model_keras2.h5')
 
 train()
+K.clear_session();


### PR DESCRIPTION
When using keras as backend, an exception like the one below occurs when tensorflow tries to close the session. Explicitly closing it resolves the issues.

```
Exception ignored in: <bound method BaseSession.__del__ of <tensorflow.python.client.session.Session object at 0x7fb65b3dbba8>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/client/session.py", line 702, in __del__
TypeError: 'NoneType' object is not callable
```