### PR TITLE
Corrected cv2.findContours

### DIFF
--- a/recognize_gesture.py
+++ b/recognize_gesture.py
@@ -107,7 +107,7 @@ def recognize():
 		thresh = cv2.merge((thresh,thresh,thresh))
 		thresh = cv2.cvtColor(thresh, cv2.COLOR_BGR2GRAY)
 		thresh = thresh[y:y+h, x:x+w]
-		contours = cv2.findContours(thresh.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[0]
+		contours = cv2.findContours(thresh.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[1]
 		if len(contours) > 0:
 			contour = max(contours, key = cv2.contourArea)
 			#print(cv2.contourArea(contour))

--- a/recognize_gesture.py
+++ b/recognize_gesture.py
@@ -108,9 +108,9 @@ def recognize():
 		thresh = cv2.cvtColor(thresh, cv2.COLOR_BGR2GRAY)
 		thresh = thresh[y:y+h, x:x+w]
 		(openCV_ver,_,__) = cv2.__version__.split(".")
-		if openCV_ver==3:
+		if openCV_ver=='3':
 			contours = cv2.findContours(thresh.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[1]
-		elif openCV_ver==4:
+		elif openCV_ver=='4':
 			contours = cv2.findContours(thresh.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[0]
 		if len(contours) > 0:
 			contour = max(contours, key = cv2.contourArea)

--- a/recognize_gesture.py
+++ b/recognize_gesture.py
@@ -107,7 +107,11 @@ def recognize():
 		thresh = cv2.merge((thresh,thresh,thresh))
 		thresh = cv2.cvtColor(thresh, cv2.COLOR_BGR2GRAY)
 		thresh = thresh[y:y+h, x:x+w]
-		contours = cv2.findContours(thresh.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[1]
+		(openCV_ver,_,__) = cv2.__version__.split(".")
+		if openCV_ver==3:
+			contours = cv2.findContours(thresh.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[1]
+		elif openCV_ver==4:
+			contours = cv2.findContours(thresh.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE)[0]
 		if len(contours) > 0:
 			contour = max(contours, key = cv2.contourArea)
 			#print(cv2.contourArea(contour))


### PR DESCRIPTION
cv2.findContours returns (image, contours, hierarchy). Therefore [1] should be used instead of [0]

Source : https://stackoverflow.com/questions/39475125/compatibility-issue-with-contourarea-in-opencv-3